### PR TITLE
Allow primary_date outside range

### DIFF
--- a/sar/sar_slc_preprocessing.py
+++ b/sar/sar_slc_preprocessing.py
@@ -4,7 +4,6 @@ import glob
 import os
 import subprocess
 import sys
-import urllib.parse
 import urllib.request
 from typing import Any, Dict, Optional
 from datetime import datetime

--- a/sar/utils/workflow_utils.py
+++ b/sar/utils/workflow_utils.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 import urllib
+import urllib.parse
 
 # __file__ could have exotic values in Docker:
 # __file__ == /src/./OpenEO_insar.py
@@ -87,6 +88,14 @@ input_dict_2018_vh_preprocessing = {
 input_dict_belgium_vv_preprocessing = {
     "burst_id": 234893,
     "primary_date": "2024-08-09",
+    "polarization": ["vv"],
+    "sub_swath": "IW1",
+    "temporal_extent": ["2024-08-09", "2024-08-21"],
+}
+
+input_dict_belgium_vv_master_outside_preprocessing = {
+    "burst_id": 234893,
+    "primary_date": "2024-09-02",
     "polarization": ["vv"],
     "sub_swath": "IW1",
     "temporal_extent": ["2024-08-09", "2024-08-21"],

--- a/tests/test_insar.py
+++ b/tests/test_insar.py
@@ -149,6 +149,7 @@ def test_insar(script, input_dict, auto_title):
     [
         # input_dict_2018_vh_preprocessing,
         input_dict_belgium_vv_vh_preprocessing,
+        input_dict_belgium_vv_master_outside_preprocessing,
         input_dict_2024_vv_preprocessing,
     ],
 )


### PR DESCRIPTION
This PR improves the dates handling in the pre_processing workflow, allowing the primary_date to be external of the temporal_extent. This will allow to split into small jobs a workflow requiring to pre-process a time series.