### PR TITLE
sar_coherence: resources requirements specification

### DIFF
--- a/cwl/sar_coherence.cwl
+++ b/cwl/sar_coherence.cwl
@@ -12,6 +12,9 @@ requirements:
     listing:
       - entryname: "arguments.json"
         entry: $(inputs)
+  ResourceRequirement:
+    ramMin: 4096
+    ramMax: 4096
 arguments:
   - arguments.json
 inputs:


### PR DESCRIPTION
The default 256MiB from the cwltool is not enough.