### PR TITLE
Add retry

### DIFF
--- a/sar/sar_coherence.py
+++ b/sar/sar_coherence.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import base64
 from datetime import timedelta
+import sys
 
 from sar.utils import simple_stac_builder
 from sar.utils import tiff_to_gtiff

--- a/sar/utils/simple_stac_builder.py
+++ b/sar/utils/simple_stac_builder.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import hashlib
 import logging
+import sys
 from contextlib import contextmanager
 from typing import Union
 

--- a/sar/utils/workflow_utils.py
+++ b/sar/utils/workflow_utils.py
@@ -1,21 +1,20 @@
 import json
+import logging.config
 import math
 import os
 import re
 import shlex
 import socket
 import subprocess
-import sys
-from datetime import datetime
-from pathlib import Path
-from typing import Any, Dict, List, Optional
-import logging.config
-
 import urllib
 import urllib.parse
 import urllib.request
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
-from openeo.utils.http import session_with_retries, DEFAULT_RETRY_FORCELIST
+import requests.adapters
+from urllib3 import Retry
 
 _log = logging.getLogger(__name__)
 
@@ -25,6 +24,14 @@ _log = logging.getLogger(__name__)
 # So we do a lot of normalization:
 repo_directory = Path(os.path.dirname(os.path.normpath(__file__).replace("//", "/"))).parent.parent.absolute()
 _log.info("repo_directory: " + str(repo_directory))
+
+
+retry = Retry(total=15, backoff_factor=2, status_forcelist={429, 500, 502, 503, 504})
+adapter = requests.adapters.HTTPAdapter(max_retries=retry)
+robust_requests_session = requests.Session()
+# noinspection HttpUrlsUsage
+robust_requests_session.mount("http://", adapter)
+robust_requests_session.mount("https://", adapter)
 
 
 def setup_insar_environment():
@@ -259,8 +266,7 @@ def retrieve_bursts_with_id_and_iw(
     https_request = "https://catalogue.dataspace.copernicus.eu/odata/v1/Bursts?$filter=" + urllib.parse.quote(
         " and ".join(filters2)) + f"&$top={page_size}"
     print(https_request)
-    session = session_with_retries({"status_forcelist": DEFAULT_RETRY_FORCELIST | {500}})
-    response = session.get(https_request)
+    response = robust_requests_session.get(https_request)
     response.raise_for_status()
     content = response.text
 

--- a/sar/utils/workflow_utils.py
+++ b/sar/utils/workflow_utils.py
@@ -15,6 +15,8 @@ import urllib
 import urllib.parse
 import urllib.request
 
+from openeo.utils.http import session_with_retries, DEFAULT_RETRY_FORCELIST
+
 _log = logging.getLogger(__name__)
 
 # __file__ could have exotic values in Docker:
@@ -257,8 +259,10 @@ def retrieve_bursts_with_id_and_iw(
     https_request = "https://catalogue.dataspace.copernicus.eu/odata/v1/Bursts?$filter=" + urllib.parse.quote(
         " and ".join(filters2)) + f"&$top={page_size}"
     print(https_request)
-    with urllib.request.urlopen(https_request) as response:
-        content = response.read().decode()
+    session = session_with_retries({"status_forcelist": DEFAULT_RETRY_FORCELIST | {500}})
+    response = session.get(https_request)
+    response.raise_for_status()
+    content = response.text
 
     bursts = json.loads(content)["value"]
     if len(bursts) >= page_size:

--- a/tests/test_insar.py
+++ b/tests/test_insar.py
@@ -5,6 +5,9 @@ import shutil
 import sys
 
 import pytest
+from pystac import Collection
+
+from sar.utils.simple_stac_builder import _cached_http
 from testutils import *
 
 _log = logging.getLogger(__name__)
@@ -42,6 +45,11 @@ def get_tiffs_from_stac_catalog(catalog_path: Path):
 
 def run_stac_catalog_and_verify(catalog_path: Path, tmp_dir: Path):
     catalog_path = Path(catalog_path)
+
+    with _cached_http():
+        # Validate again in case manual changes are made after the catalog was generated.
+        validations = Collection.from_file(str(catalog_path)).validate_all()
+        assert validations > 0
 
     tiff_files_input = get_tiffs_from_stac_catalog(catalog_path)
     assert tiff_files_input, "There should be at least one .tif file generated"

--- a/tests/test_insar_backend.py
+++ b/tests/test_insar_backend.py
@@ -125,8 +125,8 @@ def test_georeferenced_sar(cwl_path, input_dict_path, auto_title):
     )
 
     if local_openEO:
-        datacube = datacube.save_result(format="NetCDF")
-        datacube.download(tmp_dir / "result.nc")
+        stac_resource = datacube.save_result(format="NetCDF")
+        stac_resource.download(tmp_dir / "result.nc")
     else:
         stac_resource = datacube.save_result(format="GTiff") #, options={"overviews": "OFF"})
         # stac_resource = stac_resource.export_workspace(
@@ -163,6 +163,13 @@ def test_sar_preprocessing(input_dict_path, auto_title):
         "cwl": cwl,
         "context": input_dict,
     }), connection=get_connection())
+    # stac_resource = get_connection().datacube_from_process(
+    #     "run_udf",
+    #     data=None,
+    #     udf=cwl,
+    #     runtime="EOAP-CWL",
+    #     context=input_dict,
+    # )
 
     if local_openEO:
         # stac_resource.download(tmp_dir / "result.nc")


### PR DESCRIPTION
Example job where it triggered an error: `j-2605071155084ee08ebf1d1644dcbbff`
```python
File "/src/sar/utils/workflow_utils.py", line 260, in retrieve_bursts_with_id_and_iw
https://catalogue.dataspace.copernicus.eu/odata/v1/Bursts?$filter=ContentDate/Start%20ge%202023-07-14T00%3A00%3A00.000Z%20and%20ContentDate/Start%20le%202023-09-12T23%3A59%3A59.000Z%20and%20PolarisationChannels%20eq%20%27VV%27%20and%20BurstId%20eq%20359500%20and%20SwathIdentifier%20eq%20%27IW2%27&$top=1000
with urllib.request.urlopen(https_request) as response:
File "/usr/lib/python3.11/urllib/request.py", line 525, in open
return opener.open(url, data, timeout)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
response = self.parent.error(
response = meth(req, response)
^^^^^^^^^^^^^^^^^^^
File "/usr/lib/python3.11/urllib/request.py", line 634, in http_response
^^^^^^^^^^^^^^^^^^
File "/usr/lib/python3.11/urllib/request.py", line 563, in error
+33m 13s 130mserror
File "/usr/lib/python3.11/urllib/request.py", line 496, in _call_chain
return self._call_chain(*args)
^^^^^^^^^^^^^^^^^^^^^^^
result = func(*args)
^^^^^^^^^^^
File "/usr/lib/python3.11/urllib/request.py", line 643, in http_error_default
+33m 13s 131mserror
raise HTTPError(req.full_url, code, msg, hdrs, fp)
+33m 13s 132mserror
urllib.error.HTTPError: HTTP Error 429: Too Many Requests
```