### PR TITLE
Update input selection nb link

### DIFF
--- a/cwl/sar_coherence.cwl
+++ b/cwl/sar_coherence.cwl
@@ -89,7 +89,7 @@ $graph:
       burst_id:
         type: int?
         doc: |
-          A temporal extent could have multiple bursts per day. Use [this notebook](https://github.com/cloudinsar/s1-workflows/blob/main/notebooks/LPS_DEMO/Input_selection.ipynb) to find a fitting `burst_id`.
+          A temporal extent could have multiple bursts per day. Use [this notebook](https://github.com/cloudinsar/s1-workflows/blob/main/input_selection/InSAR_workflow_input_selection.ipynb) to find a fitting `burst_id`.
           Alternatively, the burst id map can be downloaded here: [Burst ID Maps 2022-05-30](https://sar-mpc.eu/files/S1_burstid_20220530.zip).
           You can also specify `temporal_extent` instead, so that a `burst_id` gets automatically selected.
       

--- a/cwl/sar_interferogram.cwl
+++ b/cwl/sar_interferogram.cwl
@@ -51,12 +51,12 @@ $graph:
           items:
             type: array
             items: string
-        doc: "The list of [primary date, secondary date] pairs used to compute the interferogram. Use [this notebook](https://github.com/cloudinsar/s1-workflows/blob/main/notebooks/LPS_DEMO/Input_selection.ipynb) to create the list of insar pairs based on your requirements."
+        doc: "The list of [primary date, secondary date] pairs used to compute the interferogram. Use [this notebook](https://github.com/cloudinsar/s1-workflows/blob/main/input_selection/InSAR_workflow_input_selection.ipynb) to create the list of insar pairs based on your requirements."
 
       burst_id:
         type: int
         doc: |
-         The Sentinel-1 burst identifier. Use [this notebook](https://github.com/cloudinsar/s1-workflows/blob/main/notebooks/LPS_DEMO/Input_selection.ipynb) to find a fitting `burst_id`.
+         The Sentinel-1 burst identifier. Use [this notebook](https://github.com/cloudinsar/s1-workflows/blob/main/input_selection/InSAR_workflow_input_selection.ipynb) to find a fitting `burst_id`.
           Alternatively, the burst id map can be downloaded here: [Burst ID Maps 2022-05-30](https://sar-mpc.eu/files/S1_burstid_20220530.zip).
 
       coherence_window_rg:

--- a/cwl/sar_slc_preprocessing.cwl
+++ b/cwl/sar_slc_preprocessing.cwl
@@ -58,7 +58,7 @@ inputs:
   burst_id:
     type: int
     doc: |
-      A temporal extent could have multiple bursts per day. Use [this notebook](https://github.com/cloudinsar/s1-workflows/blob/main/notebooks/LPS_DEMO/Input_selection.ipynb) to find a fitting `burst_id`.
+      A temporal extent could have multiple bursts per day. Use [this notebook](https://github.com/cloudinsar/s1-workflows/blob/main/input_selection/InSAR_workflow_input_selection.ipynb) to find a fitting `burst_id`.
       Alternatively, the burst id map can be downloaded here: [Burst ID Maps 2022-05-30](https://sar-mpc.eu/files/S1_burstid_20220530.zip).
   primary_date:
     type: string


### PR DESCRIPTION
The links in the CWL documentation are pointing to the old notebook, which will be removed. Subsequently even the APEx docs have the same problem.

I updated the CWL docs with the current link. @EmileSonneveld once merged you'll need to re-trigger the UDP generation and the export to the APEx docs/webpage.